### PR TITLE
Fix Windows Highlighting

### DIFF
--- a/src/highlightPlugin/index.js
+++ b/src/highlightPlugin/index.js
@@ -1,4 +1,7 @@
-import  { RichUtils } from 'draft-js';
+import  {
+  KeyBindingUtil,
+  RichUtils
+} from 'draft-js';
 
 const defaultStyle = {
   background: 'blue',
@@ -15,7 +18,7 @@ export default (style = {}) => {
       },
     },
     keyBindingFn: (e) => {
-      if (e.metaKey && e.key === 'h') {
+      if (KeyBindingUtil.hasCommandModifier(e) && e.key === 'h') {
         return 'highlight';
       }
     },


### PR DESCRIPTION
# Description
`CTRL+h` wasn't working on Windows. [Upon further inspection](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey), it is because the `metaKey` maps to `command` on Mac Os, but **not** `CTRL` on Windows. Instead of adding logic, Draft JS has a built-in Utility function for cross-platform compatability: `KeyBindingUtil.hasCommandModifier(e)`

There is documentation available [here](https://draftjs.org/docs/advanced-topics-key-bindings.html#defaults).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue) 🐛 


# How Has This Been Tested?
- [x] `npm run test` ✅ 
- [x] `npm run build` && `yarn serve -s build` ✅ 

# Checklist:

- [x] I believe I maintained style used within the existing codebase
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
